### PR TITLE
fix(tails): Fix dotnet dockerfile

### DIFF
--- a/tails/dotnet.tail.dockerfile
+++ b/tails/dotnet.tail.dockerfile
@@ -2,13 +2,14 @@ ARG LANGUAGE_VERSION=9.0
 FROM mcr.microsoft.com/dotnet/runtime:${LANGUAGE_VERSION}-alpine AS base
 WORKDIR /app
 
+FROM mcr.microsoft.com/dotnet/sdk:${LANGUAGE_VERSION}-alpine AS build
+
 ARG PROJECT_FILE=Bot
 
-FROM mcr.microsoft.com/dotnet/sdk:${LANGUAGE_VERSION}-alpine AS build
 WORKDIR /src
-COPY ${PROJECT_FILE}.csproj .
+COPY repo/${PROJECT_FILE}.csproj .
 RUN dotnet restore ${PROJECT_FILE}.csproj
-COPY . .
+COPY repo/ .
 RUN dotnet build ${PROJECT_FILE}.csproj -c Release -o /app/build
 
 FROM build AS publish
@@ -17,7 +18,7 @@ RUN dotnet publish ${PROJECT_FILE}.csproj -c Release -o /app/publish
 FROM base AS final
 WORKDIR /app
 COPY --from=publish /app/publish .
-RUN ENTRY_DLL=$(ls *.dll | grep -v '^Microsoft\|^System\|^Discord') && \
+RUN ENTRY_DLL=$(ls *.deps.json | head -n1 | awk -F. '{print $1}').dll && \
     echo "#!/bin/sh" > /entrypoint.sh && \
     echo "exec dotnet $ENTRY_DLL \"\$@\"" >> /entrypoint.sh && \
     chmod +x /entrypoint.sh


### PR DESCRIPTION
I'm unsure if the current version in this repo works in Docker's legacy build system as I no longer use it, however this is intended to fix the dockerfile to ensure functionality using Docker's new buildx system.

I also improved the assembly detection by filtering for the `*.deps.json` file which is always generated for the primary assembly, and should only be generated once per publish.

Also switched the source code working directory to `repo` as per the current tails convention.

Hope this helps!

(Force pushes were to update context in commit description)